### PR TITLE
deprecate invoiceninja 4

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -1569,6 +1569,7 @@ subtags = [ "videos" ]
 url = "https://github.com/YunoHost-Apps/invidious_ynh"
 
 [invoiceninja]
+antifeatures = [ "deprecated-software" ]
 category = "productivity_and_management"
 level = 8
 state = "working"


### PR DESCRIPTION
I don't use IN4 anymore, so from my side there won't be any fixes. This results in bugs: https://github.com/YunoHost-Apps/invoiceninja_ynh/issues/36

We discussed this already some time ago:
- https://github.com/YunoHost/apps/pull/1325
- https://github.com/YunoHost/apps/pull/1319

I hope just adding this anti-feature is enough.